### PR TITLE
Add group function

### DIFF
--- a/src/non_empty_list.gleam
+++ b/src/non_empty_list.gleam
@@ -234,7 +234,7 @@ pub fn group(
 /// ```gleam
 /// > new("a", ["b", "c"])
 /// > |> index_map(fn(index, letter) { #(index, letter) })
-/// NonEmpty(#(0, "a"), [#(1, "b"), #(2, "c")])
+/// NonEmptyList(#(0, "a"), [#(1, "b"), #(2, "c")])
 /// ```
 ///
 pub fn index_map(
@@ -312,7 +312,7 @@ pub fn last(list: NonEmptyList(a)) -> a {
 /// ```gleam
 /// > new(1, [2, 3])
 /// > |> map(fn(x) { x + 1 })
-/// NonEmpty(2, [3, 4])
+/// NonEmptyList(2, [3, 4])
 /// ```
 ///
 pub fn map(over list: NonEmptyList(a), with fun: fn(a) -> b) -> NonEmptyList(b) {
@@ -365,7 +365,7 @@ fn do_map2(
 /// ```gleam
 /// > new(1, [2, 3])
 /// > |> map_fold(from: 100, with: fn(memo, n) { #(memo + i, i * 2) })
-/// #(106, NonEmpty(2, [4, 6]))
+/// #(106, NonEmptyList(2, [4, 6]))
 /// ```
 ///
 pub fn map_fold(

--- a/src/non_empty_list.gleam
+++ b/src/non_empty_list.gleam
@@ -1,3 +1,4 @@
+import gleam/dict.{type Dict}
 import gleam/list
 import gleam/order.{type Order}
 import gleam/pair
@@ -175,6 +176,52 @@ pub fn from_list(list: List(a)) -> Result(NonEmptyList(a), Nil) {
     [] -> Error(Nil)
     [first, ..rest] -> Ok(new(first, rest))
   }
+}
+
+/// Takes a list and groups the values by a key
+/// which is built from a key function.
+///
+/// Does not preserve the initial value order.
+///
+/// ## Examples
+///
+/// ```gleam
+/// import gleam/dict
+///
+/// new(Ok(3), [Error("Wrong"), Ok(200), Ok(73)])
+/// |> group(by: fn(i) {
+///   case i {
+///     Ok(_) -> "Successful"
+///     Error(_) -> "Failed"
+///   }
+/// })
+/// |> dict.to_list
+/// // -> [
+/// //   #("Failed", NonEmptyList(Error("Wrong"), [])),
+/// //   #("Successful", NonEmptyList(Ok(73), [Ok(200), Ok(3)])),
+/// // ]
+/// ```
+///
+/// ```gleam
+/// import gleam/dict
+/// 
+/// new(1, [2,3,4,5])
+/// |> group(by: fn(i) { i - i / 3 * 3 })
+/// |> dict.to_list
+/// // -> [#(0, NonEmptyList(3, [])), #(1, NonEmptyList(4, [1])), #(2, NonEmptyList(5, [2]))]
+/// ```
+///
+pub fn group(
+  list: NonEmptyList(v),
+  by key: fn(v) -> k,
+) -> Dict(k, NonEmptyList(v)) {
+  list
+  |> to_list
+  |> list.group(by: key)
+  |> dict.map_values(fn(_, group) {
+    let assert Ok(group) = from_list(group)
+    group
+  })
 }
 
 /// Returns a new list containing only the elements of the first list after the

--- a/test/non_empty_list_test.gleam
+++ b/test/non_empty_list_test.gleam
@@ -1,3 +1,4 @@
+import gleam/dict
 import gleam/int
 import gleam/list
 import gleam/pair
@@ -102,6 +103,36 @@ pub fn from_list_test() {
   |> non_empty_list.from_list
   |> should.be_error
   |> should.equal(Nil)
+}
+
+pub fn group_test() {
+  non_empty_list.new(1, [])
+  |> non_empty_list.group(by: fn(x) { x * 4 })
+  |> should.equal(dict.from_list([#(4, non_empty_list.new(1, []))]))
+
+  non_empty_list.new(Ok(3), [Error("Wrong"), Ok(200), Ok(73)])
+  |> non_empty_list.group(by: fn(i) {
+    case i {
+      Ok(_) -> "Successful"
+      Error(_) -> "Failed"
+    }
+  })
+  |> should.equal(
+    dict.from_list([
+      #("Failed", NonEmptyList(Error("Wrong"), [])),
+      #("Successful", NonEmptyList(Ok(73), [Ok(200), Ok(3)])),
+    ]),
+  )
+
+  non_empty_list.new(1, [2, 3, 4, 5])
+  |> non_empty_list.group(by: fn(i) { i - i / 3 * 3 })
+  |> should.equal(
+    dict.from_list([
+      #(0, NonEmptyList(3, [])),
+      #(1, NonEmptyList(4, [1])),
+      #(2, NonEmptyList(5, [2])),
+    ]),
+  )
 }
 
 pub fn index_map_test() {


### PR DESCRIPTION
Closes #2 

Hello, this takes the same approach described in the issue by leaning on `list.group` and then just transforming the values from lists into non empty lists. I also cleaned up a few typos in the docs. I stole the docs from the standard library as well and then just tweaked them to work for this library.