### PR TITLE
Adds an all() and a 📏 length() function plus tests

### DIFF
--- a/src/non_empty_list.gleam
+++ b/src/non_empty_list.gleam
@@ -1,5 +1,4 @@
 import gleam/dict.{type Dict}
-import gleam/int
 import gleam/list
 import gleam/order.{type Order}
 import gleam/pair
@@ -11,9 +10,12 @@ pub type NonEmptyList(a) {
   NonEmptyList(first: a, rest: List(a))
 }
 
-/// Combines a `NonEmptyList` of `Result`s into a single `Result`. If all elements in the list are `Ok` then returns an `Ok` holding the list of values. If any element is `Error` then returns the first error.
+/// Combines a `NonEmptyList` of `Result`s into a single `Result`. If all
+///  elements in the list are `Ok` then returns an `Ok` holding the list of
+/// values. If any element is `Error` then returns the first error.
 ///
-/// This function runs in linear time, and it traverses and copies the `Ok` values or the `Error` value.
+/// This function runs in linear time, and it traverses and copies the `Ok`
+/// values or the `Error` value.
 ///
 /// ## Examples
 ///
@@ -24,25 +26,23 @@ pub type NonEmptyList(a) {
 /// ```
 ///
 /// ```gleam
-/// new(NonEmptyList(Ok(1), [Error("e")])
+/// new(Ok(1), [Error("e")])
+/// |> all
 /// // -> Error("e")
 /// ```
 ///
 pub fn all(results: NonEmptyList(Result(a, e))) -> Result(NonEmptyList(a), e) {
   case first(results) {
-    Ok(value) -> do_all(rest(results), value, [])
+    Ok(value) -> all_loop(rest(results), value, [])
     Error(error) -> Error(error)
   }
 }
 
-fn do_all(results: List(Result(a, e)), acc_first: a, acc_rest: List(a)) {
+fn all_loop(results: List(Result(a, e)), acc_first: a, acc_rest: List(a)) {
   case results {
     [Error(error), ..] -> Error(error)
-    [Ok(value), ..rest] -> do_all(rest, value, [acc_first, ..acc_rest])
-    [] ->
-      new(acc_first, acc_rest)
-      |> reverse
-      |> Ok
+    [Ok(value), ..rest] -> all_loop(rest, value, [acc_first, ..acc_rest])
+    [] -> Ok(reverse(new(acc_first, acc_rest)))
   }
 }
 
@@ -342,12 +342,13 @@ pub fn last(list: NonEmptyList(a)) -> a {
 
 /// Counts the number of elements in a given list.
 /// 
-/// This function has to traverse the list to determine the number of elements, so it runs in linear time.
+/// This function has to traverse the list to determine the number of elements,
+///  so it runs in linear time.
 ///
 /// ## Examples
 ///
 /// ```gleam
-/// > single(0)
+/// > single(0) |> length
 /// // -> 1
 /// ```
 ///
@@ -366,7 +367,7 @@ pub fn last(list: NonEmptyList(a)) -> a {
 pub fn length(of list: NonEmptyList(a)) -> Int {
   case list.first, list.rest {
     _, [] -> 1
-    _, rest -> rest |> list.length |> int.add(1)
+    _, rest -> 1 + list.length(rest)
   }
 }
 

--- a/test/non_empty_list_test.gleam
+++ b/test/non_empty_list_test.gleam
@@ -10,6 +10,17 @@ pub fn main() {
   gleeunit.main()
 }
 
+pub fn all_test() {
+  non_empty_list.new(1, [2, 3, 4])
+  |> non_empty_list.map(Ok)
+  |> non_empty_list.all
+  |> should.be_ok
+
+  non_empty_list.new(Ok(1), [Error("e")])
+  |> non_empty_list.all
+  |> should.be_error
+}
+
 pub fn append_test() {
   non_empty_list.new(1, [2, 3, 4])
   |> non_empty_list.append(non_empty_list.new(5, [6, 7]))
@@ -159,6 +170,16 @@ pub fn last_test() {
   non_empty_list.single(1)
   |> non_empty_list.last
   |> should.equal(1)
+}
+
+pub fn length_test() {
+  non_empty_list.new(1, [])
+  |> non_empty_list.length
+  |> should.equal(1)
+
+  non_empty_list.new(1, [2, 3, 4])
+  |> non_empty_list.length
+  |> should.equal(4)
 }
 
 pub fn map_test() {


### PR DESCRIPTION
Adds an all() function to mirror [result.all](https://hexdocs.pm/gleam_stdlib/gleam/result.html#all) and length() function to mirror [list.length](https://hexdocs.pm/gleam_stdlib/gleam/list.html#length), plus tests for each.